### PR TITLE
Feat/archive 로그인 상태 유지 및 마이페이지 로그아웃 구현

### DIFF
--- a/app/src/main/java/com/example/ssafy_archive/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/ssafy_archive/data/repository/UserRepository.kt
@@ -26,7 +26,7 @@ class UserRepository {
             .build()
 
         Retrofit.Builder()
-            .baseUrl("http://10.0.2.2:8080/") // 나중에 교체
+            .baseUrl("http://10.0.2.2:8080/") // 나중에 교체 http://10.0.2.2:8080/
             .client(client) // AuthInterceptor - 모든 요청에 자동으로 토큰이 붙도록 설정
             .addConverterFactory(GsonConverterFactory.create())
             .build()

--- a/app/src/main/java/com/example/ssafy_archive/ui/auth/LoginActivity.kt
+++ b/app/src/main/java/com/example/ssafy_archive/ui/auth/LoginActivity.kt
@@ -37,7 +37,6 @@ class LoginActivity : ComponentActivity() {
                             finish()
                         },
                         onBackClick = {
-                            startActivity(Intent(this, com.example.ssafy_archive.ui.intro.IntroActivity::class.java))
                             finish()
                         }
                     )

--- a/app/src/main/java/com/example/ssafy_archive/ui/auth/RegisterActivity.kt
+++ b/app/src/main/java/com/example/ssafy_archive/ui/auth/RegisterActivity.kt
@@ -33,7 +33,6 @@ class RegisterActivity : ComponentActivity() {
                             finish()
                         },
                         onBackClick = {
-                            startActivity(Intent(this, IntroActivity::class.java))
                             finish()
                         }
                     )

--- a/app/src/main/java/com/example/ssafy_archive/ui/group/GroupListActivity.kt
+++ b/app/src/main/java/com/example/ssafy_archive/ui/group/GroupListActivity.kt
@@ -1,11 +1,108 @@
 package com.example.ssafy_archive.ui.group
 
+import android.app.Activity
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.compose.BackHandler
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.ssafy_archive.ui.profile.MyPageActivity
+import com.example.ssafy_archive.ui.theme.SsafyarchiveTheme
 
 class GroupListActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        // TODO: 나중에 구현
+        setContent {
+            SsafyarchiveTheme {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color = MaterialTheme.colorScheme.background
+                ) {
+                    GroupListScreen()
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GroupListScreen() {
+    val context = LocalContext.current
+
+    // 뒤로가기 → 앱 종료
+    BackHandler {
+        (context as? Activity)?.finishAffinity()
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("그룹 리스트") },
+                actions = {
+                    TextButton(onClick = {
+                        context.startActivity(Intent(context, MyPageActivity::class.java))
+                    }) {
+                        Text("마이페이지")
+                    }
+                }
+            )
+        }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .padding(paddingValues)
+                .fillMaxSize()
+                .padding(horizontal = 24.dp)
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+            GroupListContent()
+        }
+    }
+}
+
+@Composable
+fun GroupListContent() {
+    // 임시 그룹 데이터 (추후 API 연동)
+    val dummyGroups = listOf(
+        "🔥 SSAFY 1반",
+        "📚 알고리즘 스터디",
+        "👩‍💻 안드로이드 앱팀",
+        "☕ 카페 모각코",
+        "🎮 게임 개발자 모임"
+    )
+
+    LazyColumn(
+        verticalArrangement = Arrangement.spacedBy(12.dp),
+        modifier = Modifier.fillMaxSize()
+    ) {
+        items(dummyGroups) { groupName ->
+            Card(
+                modifier = Modifier.fillMaxWidth(),
+                shape = MaterialTheme.shapes.medium,
+                elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+            ) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(20.dp),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    Text(
+                        text = groupName,
+                        style = MaterialTheme.typography.titleMedium
+                    )
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/ssafy_archive/ui/profile/MyPageActivity.kt
+++ b/app/src/main/java/com/example/ssafy_archive/ui/profile/MyPageActivity.kt
@@ -1,5 +1,6 @@
 package com.example.ssafy_archive.ui.profile
 
+import android.content.Intent
 import android.os.Bundle
 import android.widget.Toast
 import androidx.activity.ComponentActivity
@@ -14,6 +15,8 @@ import androidx.compose.ui.unit.dp
 import com.example.ssafy_archive.ui.theme.SsafyarchiveTheme
 import com.example.ssafy_archive.viewmodel.AuthViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.ssafy_archive.ui.intro.IntroActivity
+import com.example.ssafy_archive.utils.SharedPrefsManager
 
 class MyPageActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -24,6 +27,12 @@ class MyPageActivity : ComponentActivity() {
                     MyPageScreen(
                         onSaveSuccess = {
                             Toast.makeText(this, "정보가 수정되었습니다.", Toast.LENGTH_SHORT).show()
+                        },
+                        onLogout = {
+                            SharedPrefsManager(this).logout()
+                            val intent = Intent(this, IntroActivity::class.java)
+                            intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+                            startActivity(intent)
                         }
                     )
                 }
@@ -35,7 +44,8 @@ class MyPageActivity : ComponentActivity() {
 @Composable
 fun MyPageScreen(
     viewModel: AuthViewModel = viewModel(),
-    onSaveSuccess: () -> Unit
+    onSaveSuccess: () -> Unit,
+    onLogout: () -> Unit
 ) {
     var id by remember { mutableStateOf("") }
     var name by remember { mutableStateOf("") }
@@ -93,6 +103,15 @@ fun MyPageScreen(
             modifier = Modifier.fillMaxWidth()
         ) {
             Text("저장")
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedButton(
+            onClick = { onLogout() },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text("로그아웃")
         }
     }
 }

--- a/app/src/main/java/com/example/ssafy_archive/ui/splash/SplashActivity.kt
+++ b/app/src/main/java/com/example/ssafy_archive/ui/splash/SplashActivity.kt
@@ -5,29 +5,39 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.example.ssafy_archive.R
 import com.example.ssafy_archive.ui.theme.SsafyarchiveTheme
+import com.example.ssafy_archive.utils.SharedPrefsManager
 import com.example.ssafy_archive.ui.auth.LoginActivity
-import kotlinx.coroutines.delay
-import androidx.compose.ui.graphics.Color
-import androidx.compose.foundation.background
-import androidx.compose.material3.Text
+import com.example.ssafy_archive.ui.group.GroupListActivity
 import com.example.ssafy_archive.ui.intro.IntroActivity
+import kotlinx.coroutines.delay
 
 class SplashActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        val prefs = SharedPrefsManager(applicationContext)
+        val isLoggedIn = prefs.isLoggedIn
+
         setContent {
             SsafyarchiveTheme {
                 SplashScreen {
-                    startActivity(Intent(this, IntroActivity::class.java))
+                    if (isLoggedIn) {
+                        startActivity(Intent(this, GroupListActivity::class.java))
+                    } else {
+                        startActivity(Intent(this, IntroActivity::class.java))
+                    }
                     finish()
                 }
             }
@@ -47,7 +57,7 @@ fun SplashScreen(onTimeout: () -> Unit) {
             .fillMaxSize()
             .background(Color(0xFF65BDEA))
     ) {
-        // 가운데: 로고 + 버전
+        // 가운데 로고
         Column(
             modifier = Modifier.align(Alignment.Center),
             horizontalAlignment = Alignment.CenterHorizontally
@@ -57,16 +67,14 @@ fun SplashScreen(onTimeout: () -> Unit) {
                 contentDescription = "SSAFY Archive Logo",
                 modifier = Modifier.size(180.dp)
             )
-
             Spacer(modifier = Modifier.height(16.dp))
-
             Text(
                 text = "ver. 1.0.0",
                 color = Color.White
             )
         }
 
-        // 아래쪽: All rights reserved
+        // 하단 저작권 문구
         Text(
             text = "SSARCHIVE. All rights reserved.",
             color = Color.White,
@@ -76,6 +84,3 @@ fun SplashScreen(onTimeout: () -> Unit) {
         )
     }
 }
-
-
-// 65BDEA

--- a/app/src/main/java/com/example/ssafy_archive/utils/SharedPrefsManager.kt
+++ b/app/src/main/java/com/example/ssafy_archive/utils/SharedPrefsManager.kt
@@ -19,9 +19,8 @@ class SharedPrefsManager(context: Context) {
         private const val KEY_REFRESH_TOKEN = "refresh_token"
     }
 
-    var isLoggedIn: Boolean
-        get() = prefs.getBoolean(KEY_IS_LOGGED_IN, false)
-        set(value) = prefs.edit().putBoolean(KEY_IS_LOGGED_IN, value).apply()
+    val isLoggedIn: Boolean
+        get() = !accessToken.isNullOrBlank()
 
     var userId: String?
         get() = prefs.getString(KEY_USER_ID, null)
@@ -50,6 +49,13 @@ class SharedPrefsManager(context: Context) {
     var refreshToken: String?
         get() = prefs.getString(KEY_REFRESH_TOKEN, null)
         set(value) = prefs.edit().putString(KEY_REFRESH_TOKEN, value).apply()
+
+    fun clearTokens() {
+        prefs.edit()
+            .remove(KEY_ACCESS_TOKEN)
+            .remove(KEY_REFRESH_TOKEN)
+            .apply()
+    }
 
     fun logout() {
         prefs.edit().clear().apply()


### PR DESCRIPTION
### 기능 설명
- 로그인 이후 뒤로가기 시 Intro 화면이 아니라 앱 종료되도록 처리
- 불필요한 IntroActivity 재호출 방지
- 로그인 유지 상태 반영하여 Splash → GroupList 자동 진입 구현
- GroupList 화면 우측 상단에 마이페이지 버튼 추가
- 마이페이지에서 사용자 정보 수정 및 로그아웃 기능 구현

### 작업 항목
- [x] SharedPrefsManager에 isLoggedIn 여부 저장 및 불러오기 구현
- [x] SplashActivity에서 로그인 여부 판단 후 Intro 또는 GroupList 이동 처리
- [x] GroupListActivity에 뒤로가기 시 finishAffinity() 적용 (앱 종료)
- [x] GroupList 상단에 마이페이지 진입 버튼 추가
- [x] MyPageActivity 내 사용자 정보 조회 및 수정 API 연동
- [x] MyPageActivity에서 로그아웃 버튼 추가 및 IntroActivity로 리디렉션
- [x] LoginActivity 및 기타 인증 페이지에서 뒤로가기 시 IntroActivity 재호출 방지

### 참고
- SharedPrefsManager에 사용자 정보 및 토큰 저장
- AuthInterceptor에서 로그인/회원가입/리프레시 API는 예외 처리
- GroupListActivity와 MyPageActivity는 Jetpack Compose 기반으로 UI 구성

---

Closes #6 
